### PR TITLE
🔄 Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,7 @@ repos:
       - id: flake8
 
   - repo: https://github.com/PyCQA/pylint
-    rev: v2.16.3
+    rev: v2.17.0
     hooks:
       - id: pylint
         additional_dependencies:


### PR DESCRIPTION
This is a GitHub workflow (`.github/workflows/pre-commit-update.yml`) running periodically to update our pre-commit hooks' versions to their latest version.